### PR TITLE
Add line breaks for legibility improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 ## What is it for?
 
-Excessibility allows you to easily take snapshots of the DOM at any given point
-in your ExUnit or Wallaby Tests. These snapshots can then be passed to
-[pa11y](https://github.com/pa11y/pa11y) to test for WCAG compliance.
+Excessibility allows you to easily take snapshots of the DOM at any given point in your ExUnit or Wallaby Tests.<br/>
+These snapshots can then be passed to [pa11y](https://github.com/pa11y/pa11y) to test for WCAG compliance.
 
 ## Installation
 
-The package can be installed by adding `excessibility` to your list of
-dependencies in `mix.exs`:
+The package can be installed by adding `excessibility` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -33,19 +31,16 @@ To use it `require Excessibility` and then call `Excessibility.html_snapshot/2` 
 - a Wallaby Session
 - a LiveViewTest View struct
 
-It will produce an html file named with the module and line number of where it
-was called from.
+It will produce an html file named with the module and line number of where it was called from.
 
-You can pass an optional argument of `open_browser?: true` to open the snapshot
-in your browser.
+You can pass an optional argument of `open_browser?: true` to open the snapshot in your browser.
 
 ```elixir
 thing
 |> html_snapshot(open_browser?: true)
 ```
 
-The module also includes a mix task that you can call to run
-[pa11y](https://github.com/pa11y/pa11y) against the snapshots.
+The module also includes a mix task that you can call to run [pa11y](https://github.com/pa11y/pa11y) against the snapshots.<br/>
 `MIX_ENV=test mix excessibility`
 
 You may want to add `Excessbility` as an `import` or `require` in your `ConnCase` or `FeatureCase`.
@@ -61,10 +56,9 @@ config :excessibility,
 
 ## Pa11y Configuration
 
-See the [pa11y documentation](https://github.com/pa11y/pa11y#configuration) for
-configuration options.
+See the [pa11y documentation](https://github.com/pa11y/pa11y#configuration) for configuration options.
 
-Documentation can be generated with
-[ExDoc](https://github.com/elixir-lang/ex_doc) and published on
-[HexDocs](https://hexdocs.pm). Once published, the docs can be found at
+Documentation can be generated with:<br/>
+[ExDoc](https://github.com/elixir-lang/ex_doc) and published on<br/>
+[HexDocs](https://hexdocs.pm). Once published, the docs can be found at<br/>
 <https://hexdocs.pm/excessibility>.


### PR DESCRIPTION
Thanks for making it easy to add accessibility tests to elixir projects!

I noticed some possible intent in the readme that did not move over to what was rendered as the actual readme, so I thought I might add some cleanup.

There looked to be some line breaks throughout the readme that did not carry over
1. This change added `<br/>` tags to create line breaks adding `<space><space>` would also do the trick.
2. It looked like the text was wrapped due to a character count maximum text wrapping pligin. I unwrapped those lines to more closely match the rendered readme. (I can revert this, but the text wrapping makes the readme.md file look a little confusing for future editors)

Questions around your teams readme preferences:
1. Is there a preference for `<br/>` or `<space><space>` or another line break solution? 
(the intent of `space space` might get missed by a dev that we want a line break)

For ease of access here are the different Readme files to compare between:
new: https://github.com/MichaelDimmitt/excessibility/tree/readme-improvements
current: https://github.com/launchscout/excessibility/tree/376d1fa0c1ea2ea7fb3815827a6f7b086c4172e4

Happy to make changes. 
Or feel free to close this pr and head in a different direction.

Thank you!